### PR TITLE
Issue16

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,11 +6,9 @@ import json
 import os
 import logging
 
-from ms_graph import getGroupId, getGroupMembers, getUser
 from msal_interactive_flow import retrieveAccessToken
 from pathlib import Path
 from helpers import processRequest, readConfig, writeConfig
-from volterra_helpers import cliAdd, cliRemove
 
 
 @click.group()

--- a/volterra_helpers.py
+++ b/volterra_helpers.py
@@ -173,7 +173,7 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
     checkUser(email, s, c)                                                                      #Is the user present?
     if s['log'][-1]['status'] == 'present':
         userExist = True
-    if oRide:                                                                                   #Handle the override
+    if oRide:                                                                                   #Handle 'overwrite'
         if createNS:
             checkUserNS(email,s) 
             if s['log'][-1]['status'] == 'present':                                             #Is the NS present?
@@ -196,7 +196,7 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
         if userExist:                                                                           #User is present
             return {'status': 'failure', 'reason': 'User already exists', 'log': s['log']}      #No oRide -- this is fatal
         else:
-            createUserRoles(email, first_name, last_name, s, createdNS, False, admin)          #Create the user
+            createUserRoles(email, first_name, last_name, s, createdNS, False, admin)           #Create the user
             if s['log'][-1]['status'] == 'success':
                 return {'status': 'success', 'log': s['log']}
             else:

--- a/volterra_helpers.py
+++ b/volterra_helpers.py
@@ -129,10 +129,10 @@ def createUserRoles(email, first_name, last_name, s, createdNS=None, exists=Fals
             {'namespace': 'shared', 'role': 'ves-io-power-developer-role'}
         ]
     userPayload = {
-        'email': email, 
+        'email': email.lower(), 
         'first_name': first_name, 
         'last_name': last_name, 
-        'name': email, 
+        'name': email.lower(), 
         'idm_type': 'SSO', 
         'namespace': 'system', 
         'namespace_roles': namespace_roles,

--- a/volterra_helpers.py
+++ b/volterra_helpers.py
@@ -181,7 +181,10 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
             createUserNS(email, s)                                                              #Create the NS
             createdNS = findUserNS(email)                                                       #TBD: More robust -- check for success
         createUserRoles(email, first_name, last_name, s, createdNS, userExist, admin)           #Create the user with her roles
-        return {'status': 'success', 'log': s['log']}
+        if s['log'][-1]['status'] == 'success':
+            return {'status': 'success', 'log': s['log']}
+        else:
+            return {'status': 'failure', 'log': s['log']}
     else:                                                                                       #Standard use case
         if createNS:
             checkUserNS(email,s)
@@ -193,8 +196,11 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
         if userExist:                                                                           #User is present
             return {'status': 'failure', 'reason': 'User already exists', 'log': s['log']}      #No oRide -- this is fatal
         else:
-            createUserRoles(email, first_name, last_name, s, createdNS, False, admin)           #Create the user
-            return {'status': 'success', 'log': s['log']}
+            createUserRoles(email, first_name, last_name, s, createdNS, False, admin)          #Create the user
+            if s['log'][-1]['status'] == 'success':
+                return {'status': 'success', 'log': s['log']}
+            else:
+                return {'status': 'failure', 'log': s['log']}
  
 
 def cliRemove(token, tenant, email):

--- a/volterra_helpers.py
+++ b/volterra_helpers.py
@@ -184,7 +184,7 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
         if s['log'][-1]['status'] == 'success':
             return {'status': 'success', 'log': s['log']}
         else:
-            return {'status': 'failure', 'log': s['log']}
+            return {'status': 'failure', 'reason': 'User creation failed', 'log': s['log']}
     else:                                                                                       #Standard use case
         if createNS:
             checkUserNS(email,s)
@@ -200,7 +200,7 @@ def cliAdd(token, tenant, email, first_name, last_name, createNS, oRide, admin):
             if s['log'][-1]['status'] == 'success':
                 return {'status': 'success', 'log': s['log']}
             else:
-                return {'status': 'failure', 'log': s['log']}
+                return {'status': 'failure','reason': 'User creation failed', 'log': s['log']}
  
 
 def cliRemove(token, tenant, email):


### PR DESCRIPTION
PUT ops were failing because the Volterra api normalizes 'name' and 'email' properties. This caused the primary keys to not match when attempting an update.

I normalized the payload (for both POST and PUT ops) and this now works as expected.

I also added a little more robustness to cliAdd() to check the response for userCreateRole() and to pass back a generic 'reason' when there is a failure. This now shows the failure to the user without debug logging.

closes #16.
